### PR TITLE
Adding letter opener, set up development mailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,8 @@ group :development do
   gem 'spring'
 
   gem 'bullet'
+
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
     kaminari-core (1.0.1)
     launchy (2.4.3)
       addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -334,6 +336,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   kaminari
+  letter_opener
   momentjs-rails
   mqtt
   pg

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,8 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
when you're running the code in development mode - instead of sending an email for real, open a browser showing a web page containing the email that would have been sent.

