### PR TITLE
Fix/mailed link host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: 'app.wharehauora.nz' }
+  config.action_mailer.default_url_options = { host: ENV['WEB_HOST'] }
   ActionMailer::Base.smtp_settings = {
     user_name: ENV['SENDGRID_USERNAME'],
     password: ENV['SENDGRID_PASSWORD'],


### PR DESCRIPTION
Fixed emails - -when confirming or resetting passwords, the host was always set to production.
This makes it use the one set in ENV