### PR TITLE
Only home editors can assign sensors

### DIFF
--- a/app/views/rooms/index.haml
+++ b/app/views/rooms/index.haml
@@ -1,6 +1,6 @@
 = render 'homes/nav', home: @home
 
-- if policy(home).edit? && @unassigned_sensors.size.positive?
+- if policy(@home).edit? && @unassigned_sensors.size.positive?
   %h2.warning
     = fa_icon 'warning'
     new sensors detected

--- a/app/views/rooms/index.haml
+++ b/app/views/rooms/index.haml
@@ -1,6 +1,6 @@
 = render 'homes/nav', home: @home
 
-- if @unassigned_sensors.size.positive?
+- if policy(home).edit? && @unassigned_sensors.size.positive?
   %h2.warning
     = fa_icon 'warning'
     new sensors detected


### PR DESCRIPTION
the unassigned sensors were appearing even though the user cannot assign them to rooms -- this removes them so you can't see them