### PR TITLE
Protect from authenticity needs to be first

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
   include Pundit
   force_ssl if Rails.env.production?
   before_action :set_my_homes
   after_action :verify_authorized, unless: :devise_controller?
   after_action :verify_policy_scoped, only: :index
-
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found


### PR DESCRIPTION
Provide a general summary of your changes in the Title above

## Description
Rails 5 is on staging -- but sign-in is now broken. Signing in triggers Authenticity error
Under rails 5, the `protect_from_forgery` needs to be at the start of the chain of controller triggers.
