### PR TITLE
Fix runtime error in provision_mqtt!

### DIFF
--- a/app/controllers/admin/mqtt_users_controller.rb
+++ b/app/controllers/admin/mqtt_users_controller.rb
@@ -9,7 +9,7 @@ class Admin::MqttUsersController < Admin::AdminController
   def create
     authorize :mqtt_user
     @home = policy_scope(Home).find(params[:home_id])
-    @home.provision_mqtt!
+    flash[:notice] = @home.provision_mqtt!
     redirect_to admin_mqtt_users_path
   end
 end

--- a/app/controllers/admin/mqtt_users_controller.rb
+++ b/app/controllers/admin/mqtt_users_controller.rb
@@ -9,7 +9,7 @@ class Admin::MqttUsersController < Admin::AdminController
   def create
     authorize :mqtt_user
     @home = policy_scope(Home).find(params[:home_id])
-    flash[:notice] = @home.provision_mqtt!
-    redirect_to admin_mqtt_users_path
+    message = @home.provision_mqtt!
+    redirect_to admin_mqtt_users_path, notice: message
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -39,7 +39,7 @@ class HomesController < ApplicationController
 
   def update
     if @home.update(home_params)
-      @home.provision_mqtt! if @home.gateway_mac_address.present?
+      flash[:notice] = @home.provision_mqtt! if @home.gateway_mac_address.present?
     end
     respond_with(@home)
   end

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -45,14 +45,6 @@ class Home < ApplicationRecord
     "The Mac Address #{gateway_mac_address} is reused"
   end
 
-  def remove_mac_address_other_home(mac_addr)
-    Home.where.not(id: id).where(gateway_mac_address: mac_addr).update(gateway_mac_address: nil)
-  end
-
-  def delete_by_username_mqtt_user(mac_addr)
-    MqttUser.where(username: mac_addr).destroy_all
-  end
-
   def gateway
     Gateway.find_by(mac_address: gateway_mac_address)
   end
@@ -63,5 +55,13 @@ class Home < ApplicationRecord
     return if gateway_mac_address.blank?
 
     self.gateway_mac_address = gateway_mac_address.gsub(/\s/, '').delete(':').upcase
+  end
+
+  def delete_by_username_mqtt_user(mac_addr)
+    MqttUser.where(username: mac_addr).destroy_all
+  end
+
+  def remove_mac_address_other_home(mac_addr)
+    Home.where.not(id: id).where(gateway_mac_address: mac_addr).update(gateway_mac_address: nil)
   end
 end

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -42,7 +42,7 @@ class Home < ApplicationRecord
   def handle_invalid_mqtt_user(gateway_mac_address)
     delete_by_username_mqtt_user(gateway_mac_address)
     remove_mac_address_other_home(gateway_mac_address)
-    "The Mac #{gateway_mac_address} is reused"
+    "The Mac Address #{gateway_mac_address} is reused"
   end
 
   def remove_mac_address_other_home(mac_addr)

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -39,12 +39,6 @@ class Home < ApplicationRecord
     out_msg
   end
 
-  def handle_invalid_mqtt_user(gateway_mac_address)
-    delete_by_username_mqtt_user(gateway_mac_address)
-    remove_mac_address_other_home(gateway_mac_address)
-    "The Mac Address #{gateway_mac_address} is reused"
-  end
-
   def gateway
     Gateway.find_by(mac_address: gateway_mac_address)
   end
@@ -63,5 +57,11 @@ class Home < ApplicationRecord
 
   def remove_mac_address_other_home(mac_addr)
     Home.where.not(id: id).where(gateway_mac_address: mac_addr).update(gateway_mac_address: nil)
+  end
+
+  def handle_invalid_mqtt_user(gateway_mac_address)
+    delete_by_username_mqtt_user(gateway_mac_address)
+    remove_mac_address_other_home(gateway_mac_address)
+    "The Mac Address #{gateway_mac_address} is reused"
   end
 end

--- a/spec/models/home_spec.rb
+++ b/spec/models/home_spec.rb
@@ -52,36 +52,22 @@ RSpec.describe Home, type: :model do
 
     before(:each) do
       @mac_addr = '123A456B780'
-      @old_home = FactoryBot.create(:home, gateway_mac_address: @mac_addr)
-      ret_val = @old_home.provision_mqtt!
+      @home = FactoryBot.create(:home, gateway_mac_address: @mac_addr)
       @new_home = FactoryBot.build(:home, gateway_mac_address: @mac_addr)
       @new_home.save(validate: false)
     end
 
-    it 'destory MattUser with mac address existed' do
-      @new_home.send(:delete_by_username_mqtt_user, @mac_addr)
-      expect(MqttUser.where(username: @mac_addr).count).to eq 0
-    end
-
-    it 'remove gateway_mac_address in other home' do
-      @new_home.send(:remove_mac_address_other_home, @mac_addr)
-      expect(Home.where(gateway_mac_address: @mac_addr).count).to eq 1
-      expect(Home.find_by_gateway_mac_address(@mac_addr).id).to eq @new_home.id
-      expect(Home.find_by_id(@old_home.id).gateway_mac_address).to eq nil
+    it 'processing_provision with gateway_mac_address existed' do
+      @home.provision_mqtt!
+      message = @new_home.send(:processing_provision)
+      expect(message).not_to eq nil
     end
 
     it 'provision_mqtt! with gateway_mac_address existed' do
-      msg = @new_home.provision_mqtt!
-      mquser = MqttUser.where(home: @new_home).first
-      expect(mquser).to_not eq nil
-      expect(msg).not_to eq nil
+      @home.provision_mqtt!
+      message = @new_home.provision_mqtt!
+      expect(message).not_to eq nil
     end
 
-    it 'two time provision_mqtt! with gateway_mac_address existed' do
-      @new_home.provision_mqtt!
-      mquser = MqttUser.where(home: @new_home).first_or_initialize
-      @new_home.provision_mqtt!
-      expect(mquser.id).to_not eq nil
-    end
   end
 end

--- a/spec/models/home_spec.rb
+++ b/spec/models/home_spec.rb
@@ -49,22 +49,22 @@ RSpec.describe Home, type: :model do
   end
 
   describe 'provisions user with duplicate mac address' do
-    before(:each) do
-      @mac_addr = '123A456B780'
-      @home = FactoryBot.create(:home, gateway_mac_address: @mac_addr)
-      @new_home = FactoryBot.build(:home, gateway_mac_address: @mac_addr)
-      @new_home.save(validate: false)
+    let!(:home) { FactoryBot.build(:home, gateway_mac_address: '123A456B780') }
+    let!(:new_home) { FactoryBot.build(:home, gateway_mac_address: '123A456B780') }
+
+    before do
+      home.save(validate: false)
+      new_home.save(validate: false)
+      home.provision_mqtt!
     end
 
     it 'processing_provision with gateway_mac_address existed' do
-      @home.provision_mqtt!
-      message = @new_home.send(:processing_provision)
+      message = new_home.send(:processing_provision)
       expect(message).not_to eq nil
     end
 
     it 'provision_mqtt! with gateway_mac_address existed' do
-      @home.provision_mqtt!
-      message = @new_home.provision_mqtt!
+      message = new_home.provision_mqtt!
       expect(message).not_to eq nil
     end
   end

--- a/spec/models/home_spec.rb
+++ b/spec/models/home_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Home, type: :model do
   end
 
   describe 'provisions user with duplicate mac address' do
-
     before(:each) do
       @mac_addr = '123A456B780'
       @home = FactoryBot.create(:home, gateway_mac_address: @mac_addr)
@@ -68,6 +67,5 @@ RSpec.describe Home, type: :model do
       message = @new_home.provision_mqtt!
       expect(message).not_to eq nil
     end
-
   end
 end

--- a/spec/models/home_spec.rb
+++ b/spec/models/home_spec.rb
@@ -47,4 +47,41 @@ RSpec.describe Home, type: :model do
     it { expect(home.mqtt_user.username).to eq home.gateway_mac_address }
     it { expect(home.mqtt_user.password).to eq '29b4c341f18e7d0fd94edc0602e5e135' }
   end
+
+  describe 'provisions user with duplicate mac address' do
+
+    before(:each) do
+      @mac_addr = '123A456B780'
+      @old_home = FactoryBot.create(:home, gateway_mac_address: @mac_addr)
+      ret_val = @old_home.provision_mqtt!
+      @new_home = FactoryBot.build(:home, gateway_mac_address: @mac_addr)
+      @new_home.save(validate: false)
+    end
+
+    it 'destory MattUser with mac address existed' do
+      @new_home.delete_by_username_mqtt_user(@mac_addr)
+      expect(MqttUser.where(username: @mac_addr).count).to eq 0
+    end
+
+    it 'remove gateway_mac_address in other home' do
+      @new_home.remove_mac_address_other_home(@mac_addr)
+      expect(Home.where(gateway_mac_address: @mac_addr).count).to eq 1
+      expect(Home.find_by_gateway_mac_address(@mac_addr).id).to eq @new_home.id
+      expect(Home.find_by_id(@old_home.id).gateway_mac_address).to eq nil
+    end
+
+    it 'provision_mqtt! with gateway_mac_address existed' do
+      msg = @new_home.provision_mqtt!
+      mquser = MqttUser.where(home: @new_home).first
+      expect(mquser).to_not eq nil
+      expect(msg).not_to eq nil
+    end
+
+    it 'two time provision_mqtt! with gateway_mac_address existed' do
+      @new_home.provision_mqtt!
+      mquser = MqttUser.where(home: @new_home).first_or_initialize
+      @new_home.provision_mqtt!
+      expect(mquser.id).to_not eq nil
+    end
+  end
 end

--- a/spec/models/home_spec.rb
+++ b/spec/models/home_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe Home, type: :model do
     end
 
     it 'destory MattUser with mac address existed' do
-      @new_home.delete_by_username_mqtt_user(@mac_addr)
+      @new_home.send(:delete_by_username_mqtt_user, @mac_addr)
       expect(MqttUser.where(username: @mac_addr).count).to eq 0
     end
 
     it 'remove gateway_mac_address in other home' do
-      @new_home.remove_mac_address_other_home(@mac_addr)
+      @new_home.send(:remove_mac_address_other_home, @mac_addr)
       expect(Home.where(gateway_mac_address: @mac_addr).count).to eq 1
       expect(Home.find_by_gateway_mac_address(@mac_addr).id).to eq @new_home.id
       expect(Home.find_by_id(@old_home.id).gateway_mac_address).to eq nil


### PR DESCRIPTION
## Description
- When mac address already exist in homes and mqtt_users tables, runtime error happen in making a provision .
- This is because of old invalid data
- This happens because invalid data in production DB.

## Solution
- If  mac address already exists, do not make a provision
- Notification to flash message "The Mac Address #{gateway_mac_address} is already used in #{home_name} House"
