### PR TITLE
Fix creating a home with existed mac address

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -28,8 +28,11 @@ class HomesController < ApplicationController
     authorize :home
     @home = Home.new(home_params)
     invite_new_owner
-    @home.save
-    respond_with(@home, location: home_rooms_path(@home))
+    if @home.save
+      respond_with(@home, location: home_rooms_path(@home))
+    else
+      respond_with(@home)
+    end
   end
 
   def edit

--- a/spec/controllers/homes_controller_spec.rb
+++ b/spec/controllers/homes_controller_spec.rb
@@ -96,6 +96,12 @@ RSpec.describe HomesController, type: :controller do
         it { expect(subject.name).to eq "Bob\'s home" }
         it { expect(subject.owner).to eq user }
       end
+
+      describe 'Creating a home with same mac address' do
+        before { FactoryBot.create(:home, gateway_mac_address: '123A456B780') }
+        before { post :create, params: { home: { name: 'My new home', gateway_mac_address: '123A456B780' } } }
+        it { expect(response).to render_template('new') }
+      end
     end
 
     describe 'DELETE destroy' do


### PR DESCRIPTION

## Description
- When a user make a new home, and input existed mac address, a exception happens

## Description
- Go to new page again and show notification.